### PR TITLE
Add missing --root-certificates arg to flwr run and examples.

### DIFF
--- a/blossomtune_gradio/processing.py
+++ b/blossomtune_gradio/processing.py
@@ -88,6 +88,8 @@ def start_runner(
         "run",
         runner_app_path,
         "local-deployment",
+        "--root-certificates",
+        cfg.BLOSSOMTUNE_TLS_CERT_PATH,
         "--stream",
     ]
     threading.Thread(target=run_process, args=(command, "runner"), daemon=True).start()

--- a/blossomtune_gradio/settings/blossomtune.yaml
+++ b/blossomtune_gradio/settings/blossomtune.yaml
@@ -50,7 +50,8 @@ ui:
     
     *Example `flower-supernode` command:*
     ```bash
-    flower-supernode --superlink {{ superlink_hostname }}:9092 --insecure --node-config "partition-id={{ partition_id }} num-partitions={{ num_partitions }}"
+    flower-supernode --superlink {{ superlink_hostname }}:9092 --node-config "partition-id={{ partition_id }} num-partitions={{ num_partitions }}" --root-certificates=server.crt
+
     ```
 
   status_pending_md: |

--- a/flower_apps/quickstart_huggingface/pyproject.toml
+++ b/flower_apps/quickstart_huggingface/pyproject.toml
@@ -59,4 +59,4 @@ options.backend.client-resources.num-gpus = 0.0 # at most 4 ClientApp will run i
 
 [tool.flwr.federations.local-deployment]
 address = "0.0.0.0:9093"
-insecure = true
+insecure = false


### PR DESCRIPTION
Adds missing `--root-certificates` arg to flwr run and examples.