### PR TITLE
Add --federation-config argument to flwr run command

### DIFF
--- a/blossomtune_gradio/processing.py
+++ b/blossomtune_gradio/processing.py
@@ -88,6 +88,8 @@ def start_runner(
         "run",
         runner_app_path,
         "local-deployment",
+        "--federation-config",
+        f"address={cfg.SUPERLINK_HOST} root-certificates={cfg.BLOSSOMTUNE_TLS_CERT_PATH}",
         "--stream",
     ]
     threading.Thread(target=run_process, args=(command, "runner"), daemon=True).start()

--- a/flower_apps/quickstart_huggingface/pyproject.toml
+++ b/flower_apps/quickstart_huggingface/pyproject.toml
@@ -59,4 +59,4 @@ options.backend.client-resources.num-gpus = 0.0 # at most 4 ClientApp will run i
 
 [tool.flwr.federations.local-deployment]
 address = "0.0.0.0:9093"
-root-certificates = "/data/certs/server.crt" # hardcoded for now.
+insecure = true


### PR DESCRIPTION
Adds `--federation-config` argument to `flwr run` command to override `address` and `root-certificates` flower app configs